### PR TITLE
User `underscore` instead of `downcase` for creating translation keys

### DIFF
--- a/lib/enum_help/i18n.rb
+++ b/lib/enum_help/i18n.rb
@@ -10,7 +10,7 @@ module EnumHelp
         i18n_method_name = "#{name}_i18n".to_sym
         define_method(i18n_method_name) do
           enum_value = self.send(name)
-          ::I18n.t("enums.#{klass.to_s.downcase}.#{name}.#{enum_value}", default: enum_value)
+          ::I18n.t("enums.#{klass.to_s.underscore}.#{name}.#{enum_value}", default: enum_value)
         end
       end
     end

--- a/lib/enum_help/simple_form.rb
+++ b/lib/enum_help/simple_form.rb
@@ -17,7 +17,7 @@ module EnumHelp
       def initialize(*args)
         super
         raise "Attribute '#{attribute_name}' has no enum class" unless enum = object.class.send(attribute_name.to_s.pluralize)
-        collect = enum.collect{|k,v| [::I18n.t("enums.#{object.class.to_s.downcase}.#{attribute_name}.#{k}", default: k),k] }
+        collect = enum.collect{|k,v| [::I18n.t("enums.#{object.class.to_s.underscore}.#{attribute_name}.#{k}", default: k),k] }
         # collect.unshift [args.last[:prompt],''] if args.last.is_a?(Hash) && args.last[:prompt]
 
         if respond_to?(:input_options)


### PR DESCRIPTION
So key for `ClassWithLongName` is correctly set to `class_with_long_name`.
