### PR TITLE
Collect enum only if both collection options are blank

### DIFF
--- a/lib/enum_help/simple_form.rb
+++ b/lib/enum_help/simple_form.rb
@@ -16,8 +16,8 @@ module EnumHelp
 
       def initialize(*args)
         super
-        raise "Attribute '#{attribute_name}' has no enum class" unless enum = object.class.send(attribute_name.to_s.pluralize)
-        return unless input_options[:collection].blank? && @builder.options[:collection].blank?
+        enum = input_options[:collection] || @builder.options[:collection]
+        raise "Attribute '#{attribute_name}' has no enum class" unless enum ||= object.class.send(attribute_name.to_s.pluralize)
 
         collect = enum.collect{|k,v| [::I18n.t("enums.#{object.class.to_s.underscore}.#{attribute_name}.#{k}", default: k),k] }
         # collect.unshift [args.last[:prompt],''] if args.last.is_a?(Hash) && args.last[:prompt]


### PR DESCRIPTION
I want to pass a restricted enums hash. Example:

```
class Foo < ActiveRecord::Base
  enum status: { pending: 0, submitted: 1, approved: 2, active: 3, rejected: 4 }

  def self.restricted_statuses
    statuses.except :approved, :rejected
  end

end
```

In my app, depending on user role, you could see all statuses (`Foo.statuses`) or only specific ones (`Foo.restricted_statuses`). I was hoping to utilize simple_form's `:collection` key to do this:

`= f.input :status, collection: Foo.restricted_statuses`

however I noticed that enum_help does not use the `:collection` key.
