### PR TITLE
Fix simple_form regression

### DIFF
--- a/lib/enum_help/i18n.rb
+++ b/lib/enum_help/i18n.rb
@@ -41,14 +41,10 @@ module EnumHelp
       collection_i18n_method_name = "#{collection_method_name}_i18n"
 
       klass.instance_eval <<-METHOD, __FILE__, __LINE__
-      def #{collection_i18n_method_name}(*args)
-        options = args.extract_options!
-        collection = args[0] || send(:#{collection_method_name})
-        collection.except! options[:except] if options[:except]
-
-        collection.map do |label, value|
-          [::EnumHelp::Helper.translate_enum_label(self, :#{attr_name}, label), value]
-        end.to_h
+      def #{collection_i18n_method_name}
+        #{collection_method_name}.collect do |label, _|
+          [label, ::EnumHelp::Helper.translate_enum_label(self, :#{attr_name}, label)]
+        end.to_h.with_indifferent_access
       end
       METHOD
     end

--- a/lib/enum_help/simple_form.rb
+++ b/lib/enum_help/simple_form.rb
@@ -31,7 +31,14 @@ module EnumHelp
         enum = input_options[:collection] || @builder.options[:collection]
         raise "Attribute '#{attribute_name}' has no enum class" unless enum ||= object.class.send(attribute_name.to_s.pluralize)
 
-        collect = object.class.send("#{attribute_name.to_s.pluralize}_i18n", enum.to_h).to_a
+        enum = enum.keys if enum.is_a? Hash
+
+        collect = begin
+          collection = object.class.send("#{attribute_name.to_s.pluralize}_i18n")
+          collection.slice!(*enum) if enum
+          collection.invert.to_a
+        end
+
         # collect.unshift [args.last[:prompt],''] if args.last.is_a?(Hash) && args.last[:prompt]
 
         if respond_to?(:input_options)


### PR DESCRIPTION
Hi,

I just fixed a regression on the simple_form integration module, I’m sorry! I guess we need some tests, but that’s OK for now :)

It blew up with a collection like this, which previously worked:

``` ruby
f.input :status, collection: [:editing, :approved] # Ops...
```

Note that it also accepts an input format like this (shown in the README file):

``` ruby
f.input :status, collection: Foo.statuses.except(:draft)
```

I also needed to changed the format of the hash returned by “Foo.collection_i18n” to something more useful. It was in the following format: { ‘Translated key’ => integer code }. I realized the integer code had little to no use, because integer codes are meant to be used internally by the model. They shouldn’t be needed on the views. I guess the “Foo.statuses” (or similar) method that comes with Rails is meant for querying the database, and I see little use outside that context. For example:

``` ruby
Foo.where status: Foo.statuses[‘editing'] # Fetches all foos with “editing” status
```

The new i18n collection hash can be used like this, which is much more useful:

``` ruby
translated_statuses = Foo.statuses_i18n
translated_statuses['editing’] # Returns the translation of the “editing” status
```

That method is also useful because:
- There is a centralised place to fetch all the translations for an enum attribute, if the user needs to (the simple form extension also fetches the translations from that method)
- The user can easily query a translation for any enum label, like shown above
- The user doesn’t need to mess with a raw i18n query (enums.model.field.label)

I also retired the “except” option previously accepted by the i18n collection method. Now that the keys are the enum identifiers, we don’t need that anymore. Instead we can do:

``` ruby
Foo.statuses_i18n.except(:editing) # Or...
Foo.statuses_i18n.slice(:editing)
```

I’ll be glad to hear an opinion from you, thanks.
