### PR TITLE
use the method of defined_enums in the judgement of enum

### DIFF
--- a/lib/enum_help/simple_form.rb
+++ b/lib/enum_help/simple_form.rb
@@ -18,7 +18,7 @@ module EnumHelp
 
 
       def is_enum_attributes?( attribute_name )
-        object.class.respond_to?(attribute_name.pluralize) && attribute_name.pluralize != "references"
+        object.class.defined_enums.key?(attribute_name)
       end
 
 


### PR DESCRIPTION
"object.class.respond_to?(attribute_name.pluralize) " to affect all of method named pluralize.
 "defined_enums" can be judged only enums.

example error pattern...
--------------------------------------------------------------------
### rails model
```ruby
class Blog < ActiveRecord::Base
  BLOG_TYPES = { "AType" => "Daily", "BType" => "Weekly" }
  def self.blog_types
    return BLOG_TYPES
  end
end
```

### rails view
```erb
<%= simple_form_for(@blog) do |f| %>
  <%= f.input :blog_type, collection: Blog.blog_types %>
<% end %>
```
### raise execptin
undefined method `area_types_i18n' 