### PR TITLE
fix regression on simple_form forms without AR objects

### DIFF
--- a/lib/enum_help/simple_form.rb
+++ b/lib/enum_help/simple_form.rb
@@ -18,7 +18,9 @@ module EnumHelp
 
 
       def is_enum_attributes?( attribute_name )
-        object.class.defined_enums.key?(attribute_name) && attribute_name.pluralize != "references"
+        object.class.respond_to?(:defined_enums) &&
+          object.class.defined_enums.key?(attribute_name) &&
+          attribute_name.pluralize != "references"
       end
 
 


### PR DESCRIPTION
Hi there

Latest version included a small regression on forms like this : 

```
= simple_form_for :session do |f|
```

Because :session is a symbol and not an object responding to defined_enums.

So here's a small fix