### PR TITLE
Show Humanized label instead of raw enum_symbol

### DIFF
--- a/lib/enum_help/i18n.rb
+++ b/lib/enum_help/i18n.rb
@@ -51,7 +51,7 @@ module EnumHelp
     end
 
     def self.translate_enum_label(klass, attr_name, enum_label)
-      ::I18n.t("enums.#{klass.to_s.underscore}.#{attr_name}.#{enum_label}", default: enum_label)
+      ::I18n.t("enums.#{klass.to_s.underscore}.#{attr_name}.#{enum_label}", default: enum_label.humanize)
     end
 
   end


### PR DESCRIPTION
When there are no I18n translations, `humanize` the Enum labels (in collections sent to form builders) instead of showing the raw symbol.

Old output:

    <select name="response[status]" id="response_status" class="enum optional form-control">
      <option value="multiple_choices">multiple_choices</option>
      <option value="bad_request">bad_request</option>
      <option value="internal_server_error">internal_server_error</option>
    </select>

New output:

    <select name="response[status]" id="response_status" class="enum optional form-control">
      <option value="multiple_choices">Multiple choices</option>
      <option value="bad_request">Bad request</option>
      <option value="internal_server_error">Internal server error</option>
    </select>

This allows users to see prettier labels. If I18n translations are set up, those will be used instead.