### PR TITLE
Fixes issue translations of enums in STI subclasses

### DIFF
--- a/lib/enum_help/i18n.rb
+++ b/lib/enum_help/i18n.rb
@@ -28,7 +28,7 @@ module EnumHelp
       def #{attr_i18n_method_name}
         enum_label = self.send(:#{attr_name})
         if enum_label
-          ::EnumHelp::Helper.translate_enum_label(self.class, :#{attr_name}, enum_label)
+          ::EnumHelp::Helper.translate_enum_label(#{klass}, :#{attr_name}, enum_label)
         else
           nil
         end


### PR DESCRIPTION
In case that a model uses STI, for example as following:

```
class Animal
  enum emotion: [:happy, :sad, :bored]
end

class Dog < Animal
end

class Cat < Animal
end
```

we had to define the translation separately for the cat and dog. This doesn't make sense as it is defined in their parent class and means a big overhead of duplicated translations in case of more complex models.  
