### PR TITLE
fix namespaced models

### DIFF
--- a/lib/enum_help/i18n.rb
+++ b/lib/enum_help/i18n.rb
@@ -51,7 +51,7 @@ module EnumHelp
     end
 
     def self.translate_enum_label(klass, attr_name, enum_label)
-      ::I18n.t("enums.#{klass.to_s.underscore}.#{attr_name}.#{enum_label}", default: enum_label.humanize)
+      ::I18n.t("enums.#{klass.to_s.underscore.gsub('/', '.')}.#{attr_name}.#{enum_label}", default: enum_label.humanize)
     end
 
   end


### PR DESCRIPTION
If we have any namespaced model like `Admin::Service`, enum_help doesn't work,
because` 'Admin::Service'.underscore => admin/service,` ([proof](http://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-underscore))
After this commit` => 'admin.service'`, so this yaml structure for namespaced model will work:
```
admin:
 service:
  content_type:
    image: 'Awesome image'
```