### PR TITLE
Implement EnumHelp::Helper::define_collection_i18n_options_method

### DIFF
--- a/lib/enum_help/i18n.rb
+++ b/lib/enum_help/i18n.rb
@@ -8,6 +8,7 @@ module EnumHelp
       definitions.each do |name, _|
         Helper.define_attr_i18n_method(self, name)
         Helper.define_collection_i18n_method(self, name)
+        Helper.define_collection_i18n_options_method(self, name)
       end
     end
 
@@ -44,6 +45,20 @@ module EnumHelp
       def #{collection_i18n_method_name}
         collection_array = #{collection_method_name}.collect do |label, _|
           [label, ::EnumHelp::Helper.translate_enum_label(self, :#{attr_name}, label)]
+        end
+        Hash[collection_array].with_indifferent_access
+      end
+      METHOD
+    end
+
+    def self.define_collection_i18n_options_method(klass, attr_name)
+      collection_method_name = "#{attr_name.to_s.pluralize}"
+      collection_i18n_options_method_name = "#{collection_method_name}_i18n_options"
+
+      klass.instance_eval <<-METHOD, __FILE__, __LINE__
+      def #{collection_i18n_options_method_name}
+        collection_array = #{collection_method_name}.collect do |label, value|
+          [::EnumHelp::Helper.translate_enum_label(self, :#{attr_name}, label), value]
         end
         Hash[collection_array].with_indifferent_access
       end

--- a/lib/enum_help/i18n.rb
+++ b/lib/enum_help/i18n.rb
@@ -43,10 +43,12 @@ module EnumHelp
 
       klass.instance_eval <<-METHOD, __FILE__, __LINE__
       def #{collection_i18n_method_name}
-        collection_array = #{collection_method_name}.collect do |label, _|
-          [label, ::EnumHelp::Helper.translate_enum_label(self, :#{attr_name}, label)]
+        @#{collection_i18n_method_name} ||= begin
+          collection_array = #{collection_method_name}.collect do |label, _|
+            [label, ::EnumHelp::Helper.translate_enum_label(self, :#{attr_name}, label)]
+          end
+          Hash[collection_array].with_indifferent_access
         end
-        Hash[collection_array].with_indifferent_access
       end
       METHOD
     end
@@ -57,10 +59,12 @@ module EnumHelp
 
       klass.instance_eval <<-METHOD, __FILE__, __LINE__
       def #{collection_i18n_options_method_name}
-        collection_array = #{collection_method_name}.collect do |label, value|
-          [::EnumHelp::Helper.translate_enum_label(self, :#{attr_name}, label), value]
+        @#{collection_i18n_options_method_name} ||= begin
+          collection_array = #{collection_method_name}.collect do |label, value|
+            [::EnumHelp::Helper.translate_enum_label(self, :#{attr_name}, label), value]
+          end
+          Hash[collection_array].with_indifferent_access
         end
-        Hash[collection_array].with_indifferent_access
       end
       METHOD
     end

--- a/lib/enum_help/i18n.rb
+++ b/lib/enum_help/i18n.rb
@@ -24,15 +24,12 @@ module EnumHelp
 
     def self.define_attr_i18n_method(klass, attr_name)
       attr_i18n_method_name = "#{attr_name}_i18n"
+      collection_i18n_method_name = "#{attr_name.to_s.pluralize}_i18n"
 
       klass.class_eval <<-METHOD, __FILE__, __LINE__
       def #{attr_i18n_method_name}
         enum_label = self.send(:#{attr_name})
-        if enum_label
-          ::EnumHelp::Helper.translate_enum_label(self.class, :#{attr_name}, enum_label)
-        else
-          nil
-        end
+        class.send(:#{collection_i18n_method_name})[enum_label]
       end
       METHOD
     end


### PR DESCRIPTION
## Add EnumHelp::Helper::define_collection_i18n_options_method

I want to use like this with Formtastic.

```ruby
filter :category, as: :select, collection: Article.categories_i18n_options
```

![](https://cloud.githubusercontent.com/assets/15371677/17952628/4b3ab782-6aa7-11e6-98c0-9471d620fe62.png)

## Memoize

Memoize result of collection methods for performance.

## #attr_i18n_method fetching from result of collection method

For performance.