### PR TITLE
ids as values

### DIFF
--- a/lib/enum_help/i18n.rb
+++ b/lib/enum_help/i18n.rb
@@ -41,9 +41,9 @@ module EnumHelp
       collection_i18n_method_name = "#{collection_method_name}_i18n"
 
       klass.instance_eval <<-METHOD, __FILE__, __LINE__
-      def #{collection_i18n_method_name}
-        collection_array = #{collection_method_name}.collect do |label, _|
-          [label, ::EnumHelp::Helper.translate_enum_label('#{klass}', :#{attr_name}, label)]
+      def #{collection_i18n_method_name}(ids = :lables)
+        collection_array = #{collection_method_name}.collect do |label, value|
+          [(ids == :values ? value : label), ::EnumHelp::Helper.translate_enum_label('#{klass}', :#{attr_name}, label)]
         end
         Hash[collection_array].with_indifferent_access
       end

--- a/lib/enum_help/simple_form.rb
+++ b/lib/enum_help/simple_form.rb
@@ -33,10 +33,12 @@ module EnumHelp
         enum = input_options[:collection] || @builder.options[:collection]
         raise "Attribute '#{attribute_name}' has no enum class" unless enum ||= object.class.send(attribute_name.to_s.pluralize)
 
-        enum = enum.keys if enum.is_a? Hash
+        if enum.is_a? Hash
+          enum = input_options[:ids] == :values ? enum.values : enum.keys
+        end
 
         collect = begin
-          collection = object.class.send("#{attribute_name.to_s.pluralize}_i18n")
+          collection = object.class.send("#{attribute_name.to_s.pluralize}_i18n", input_options[:ids])
           collection.slice!(*enum) if enum
           collection.invert.to_a
         end


### PR DESCRIPTION
Sometimes users need to have select tag like 
```html
<select name="status">
 <option value="0">Pending</option>
 <option value="1">Confirmed</option>
</select>
```
instead of 
```html
<select name="status">
 <option value="pending">Confirmed</option>
 <option value="confirmed">Confirmed</option>
</select>
```
It could be usefull when selectbox is filter-contol element, so developer need to do 
```Item.where(status: params[:status])``` instead of ```Item.where(status: Item.statuses(params[:status]))```