### PR TITLE
Added support for check boxes with i18n labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,12 @@ e.g.
 <%= f.input :status, as: :radio_buttons %>
 ```
 
+Check boxes with i18n labels are supported as well (use a serialized array in ActiveRecord):
 
+e.g.
+```erb
+<%= f.input :vaccinations, as: :check_boxes %>
+```
 
 
 I18n local file example:

--- a/lib/enum_help/simple_form.rb
+++ b/lib/enum_help/simple_form.rb
@@ -9,6 +9,8 @@ module EnumHelp
         options = args.last
         return :enum_radio_buttons if options.is_a?(Hash) && options[:as] == :radio_buttons &&
                                       is_enum_attributes?( att_name )
+        return :enum_check_boxes if options.is_a?(Hash) && options[:as] == :check_boxes &&
+                                    is_enum_attributes?( att_name )
 
         return :enum if (options.is_a?(Hash) ? options[:as] : @options[:as]).nil? &&
                         is_enum_attributes?( att_name )
@@ -69,12 +71,18 @@ class EnumHelp::SimpleForm::EnumRadioButtons < ::SimpleForm::Inputs::CollectionR
 
 end
 
+class EnumHelp::SimpleForm::EnumCheckBoxes < ::SimpleForm::Inputs::CollectionCheckBoxesInput
+  include EnumHelp::SimpleForm::InputExtension
+
+end
 
 SimpleForm::FormBuilder.class_eval do
   prepend EnumHelp::SimpleForm::BuilderExtension
 
   map_type :enum,               :to => EnumHelp::SimpleForm::EnumInput
   map_type :enum_radio_buttons, :to => EnumHelp::SimpleForm::EnumRadioButtons
+  map_type :enum_check_boxes,   :to => EnumHelp::SimpleForm::EnumCheckBoxes
   alias_method :collection_enum_radio_buttons, :collection_radio_buttons
+  alias_method :collection_enum_check_boxes, :collection_check_boxes
   alias_method :collection_enum, :collection_select
 end


### PR DESCRIPTION
Works for serialized arrays. For example, created by:

```
add_column :treatments, :vaccinations, :integer, array: true, default: []
```

And in your model:

```
class Treatment < ApplicationRecord
  enum vaccinations: { flu: 0, polio: 1 }
end
```

In the view:

```
= f.input :vaccinations, as: :check_boxes
```

Translations would be:

```
de:
  enums:
    treatment:
      vaccinations:
        flu: "Last year's flu"
        polio: Polio
```