### PR TITLE
Add define_collection_i18n_method_before_type_cast

### DIFF
--- a/lib/enum_help/i18n.rb
+++ b/lib/enum_help/i18n.rb
@@ -8,6 +8,7 @@ module EnumHelp
       definitions.each do |name, _|
         Helper.define_attr_i18n_method(self, name)
         Helper.define_collection_i18n_method(self, name)
+        Helper.define_collection_i18n_method_before_type_cast(self, name)
       end
     end
 
@@ -44,6 +45,19 @@ module EnumHelp
       def #{collection_i18n_method_name}
         collection_array = #{collection_method_name}.collect do |label, _|
           [label, ::EnumHelp::Helper.translate_enum_label('#{klass}', :#{attr_name}, label)]
+        end
+        Hash[collection_array].with_indifferent_access
+      end
+      METHOD
+    end
+
+    def self.define_collection_i18n_method_before_type_cast(klass, attr_name)
+      collection_method_name = "#{attr_name.to_s.pluralize}"
+      collection_i18n_method_name = "#{collection_method_name}_i18n_before_type_cast"
+      klass.instance_eval <<-METHOD, __FILE__, __LINE__
+      def #{collection_i18n_method_name}
+        collection_array = #{collection_method_name}.collect do |label, _|
+          [#{klass.public_send(collection_method_name)}[label], ::EnumHelp::Helper.translate_enum_label('#{klass}', :#{attr_name}, label)]
         end
         Hash[collection_array].with_indifferent_access
       end


### PR DESCRIPTION
Add define_collection_i18n_method_before_type_cast method.


Since the ransack gem does not support enum string search,
I added a method that returns a before type cast value.

```ruby
[1] pry(main)> Advertiser.statuses_i18n
=> {"default"=>"未承認", "approved"=>"承認", "rejected"=>"否認"}
[2] pry(main)> Advertiser.statuses_i18n_before_type_cast
=> {10=>"未承認", 20=>"承認", 30=>"否認"}
```