### PR TITLE
Run CI on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - head
+          - 3.1
+          - "3.0"
+          - 2.7
+          - 2.6
+        rails-version:
+          - "edge"
+          - "~> 7.0.1"
+          - "~> 6.1.4"
+          - "~> 6.0.4"
+          - "~> 5.2.6"
+        exclude:
+          - ruby-version: head
+            rails-version: "~> 5.2.6"
+          - ruby-version: 3.1
+            rails-version: "~> 5.2.6"
+          - ruby-version: "3.0"
+            rails-version: "~> 5.2.6"
+          - ruby-version: 2.6
+            rails-version: "edge"
+          - ruby-version: 2.6
+            rails-version: "~> 7.0.1"
+    env:
+      RAILS_VERSION: "${{ matrix.rails-version }}"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{ matrix.ruby-version }}"
+          bundler-cache: true
+      - run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,17 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in enum_help.gemspec
 gemspec
+
+gem 'bundler'
+gem 'rake'
+gem 'rspec'
+gem 'sqlite3'
+
+case version = ENV['RAILS_VERSION']
+when nil
+  gem 'rails', '~> 7.0'
+when 'edge'
+  gem 'rails', github: 'rails/rails'
+else
+  gem 'rails', version
+end

--- a/enum_help.gemspec
+++ b/enum_help.gemspec
@@ -18,11 +18,5 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "rails", "~> 7.0"
-
   spec.add_dependency "activesupport", ">= 3.0.0"
 end

--- a/spec/enum_i18n_help_spec.rb
+++ b/spec/enum_i18n_help_spec.rb
@@ -3,7 +3,11 @@ require 'spec_helper'
 EnumHelp::Railtie.initializers.each(&:run)
 
 class User < ActiveRecord::Base
-  enum gender: [:male, :female], _default: :male
+  if ActiveRecord.version < Gem::Version.new('6.1')
+    enum gender: [:male, :female]
+  else
+    enum gender: [:male, :female], _default: :male
+  end
 
   enum status: %i[normal disable]
 end

--- a/spec/support/setup_database.rb
+++ b/spec/support/setup_database.rb
@@ -1,7 +1,8 @@
 ActiveRecord::Base.configurations = { "test"=> {"adapter"=>"sqlite3", "database"=>":memory:"} }
 ActiveRecord::Base.establish_connection :test
 
-class CreateAllTables < ActiveRecord::Migration[7.0]
+version = "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
+class CreateAllTables < ActiveRecord::Migration[version]
   def change
     create_table :users do |t|
       t.integer :gender, null: false, default: 0, limit: 1


### PR DESCRIPTION
We can notice regressions or changes with the latest Rails and Ruby.

* Use Gemfile instead of Gem::Specification#add_development_dependency
* Test with multiple Rails versions of the matrix
* Specify the Rails version dynamically
* Since Rails 6.1 it has been possible to set a default value of enum attributes
  refs: https://www.bigbinary.com/blog/rails-6-1-allows-enums-attributes-to-have-default-value