### PR TITLE
Show rubygems badge and CI status badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # EnumHelp
 
+[![Gem Version](https://badge.fury.io/rb/enum_help.svg)](https://rubygems.org/gems/enum_help)
+[![Build Status](https://github.com/zmbacker/enum_help/actions/workflows/ci.yml/badge.svg)](https://github.com/zmbacker/enum_help/actions/workflows/ci.yml)
+
 Help ActiveRecord::Enum feature to work fine with I18n and simple_form.
 
 Make Enum field correctly generate select field.


### PR DESCRIPTION
This PR adds two badges on README.
![ss](https://user-images.githubusercontent.com/32959831/148772821-12b3ef91-4b2a-476d-8b45-6fcccadb1221.png)

