### PR TITLE
Fix the locale of fixtures

### DIFF
--- a/spec/fixtures/locales/en.yml
+++ b/spec/fixtures/locales/en.yml
@@ -1,4 +1,4 @@
-zh-CN:
+en:
   activerecord:
     models:
       user: "User"


### PR DESCRIPTION
This PR fixes the locale of `en.yml`.