### PR TITLE
Address new syntax in Rails 7.0

### DIFF
--- a/lib/enum_help/i18n.rb
+++ b/lib/enum_help/i18n.rb
@@ -2,19 +2,22 @@ module EnumHelp
 
   module I18n
 
-    if ActiveRecord::VERSION::MAJOR == 7
+    if ActiveRecord::VERSION::MAJOR >= 7
       # overwrite the enum method
       def enum(name = nil, values = nil, **options)
         super(name, values, **options)
-
-        definitions = options.slice!(:_prefix, :_suffix, :_scopes, :_default)
-        definitions.each do |name, _|
+        if name # For new syntax in Rails7
           Helper.define_attr_i18n_method(self, name)
           Helper.define_collection_i18n_method(self, name)
+        else
+          definitions = options.slice!(:_prefix, :_suffix, :_scopes, :_default)
+          definitions.each do |name, _|
+            Helper.define_attr_i18n_method(self, name)
+            Helper.define_collection_i18n_method(self, name)
+          end
         end
       end
-    end
-    if ActiveRecord::VERSION::MAJOR < 7
+    else
       # overwrite the enum method
       def enum( definitions )
         super( definitions )

--- a/spec/enum_i18n_help_spec.rb
+++ b/spec/enum_i18n_help_spec.rb
@@ -5,8 +5,10 @@ EnumHelp::Railtie.initializers.each(&:run)
 class User < ActiveRecord::Base
   if ActiveRecord.version < Gem::Version.new('6.1')
     enum gender: [:male, :female]
-  else
+  elsif ActiveRecord.version < Gem::Version.new('7.0')
     enum gender: [:male, :female], _default: :male
+  else # Rails 7.0 or higher
+    enum :gender, [:male, :female], default: :male
   end
 
   enum status: %i[normal disable]

--- a/spec/fixtures/locales/en.yml
+++ b/spec/fixtures/locales/en.yml
@@ -1,4 +1,4 @@
-zh-CN:
+en:
   activerecord:
     models:
       user: "User"


### PR DESCRIPTION
### Summary

This PR addresses [new syntax](https://github.com/rails/rails/pull/41328) introduced in Rails 7.0.
Also fixes the locale of `spec/fixtures/locales/en.yml` to prevent CI from failing.

### Repro
```ruby
class User < ActiveRecord::Base
  enum :gender, [:male, :female], default: :male
end

User.genders_i18n
```

Before:
```
NoMethodError:
  undefined method `genders_i18n' for User:Class
  Did you mean?  genders
```

After:
```
{"male"=>"Male", "female"=>"Female"}
```