### PR TITLE
Return value of `enum` so it remains compatible with other enum extensions (e.g. stateful_enum)

### DIFF
--- a/lib/enum_help/i18n.rb
+++ b/lib/enum_help/i18n.rb
@@ -5,7 +5,8 @@ module EnumHelp
     if ActiveRecord::VERSION::MAJOR >= 7
       # overwrite the enum method
       def enum(name = nil, values = nil, **options)
-        super(name, values, **options)
+        definitions = super
+
         if name # For new syntax in Rails7
           Helper.define_attr_i18n_method(self, name)
           Helper.define_collection_i18n_method(self, name)
@@ -16,6 +17,8 @@ module EnumHelp
             Helper.define_collection_i18n_method(self, name)
           end
         end
+
+        definitions
       end
     else
       # overwrite the enum method


### PR DESCRIPTION
## What does this PR do?

`EnumHelp::I18n` re-defines `ActiveRecord::Base#enum` but did **not** return the
value from `super`.  
When another gem (notably **stateful_enum**) wraps `enum` and expects the
original `Hash` definition to be returned, the call chain receives `nil` (or a
`Symbol`) and crashes with:

```
NoMethodError: undefined method `map' for nil:NilClass
    .../stateful_enum/machine.rb:8:in `initialize'
```

This PR stores the result of `super`, executes EnumHelp’s I18n helpers, and
finally **returns the original result object**.  
No other behaviour is changed.

---

## Why is it needed?

* Allows `enum_help` to coexist with popular gems that decorate `enum`
  (`stateful_enum` etc.).
* Removes the need for ad-hoc monkey-patches in downstream applications.

---

## Implementation details

```ruby
definitions = super           # call the next #enum implementation
…                         # existing i18n helper definitions
definitions                    # ← **return it**
```

*No other lines were modified.*

---

## Backwards compatibility

* The change only affects the **return value**; public APIs and generated I18n
  helper methods are untouched.

---

Thank you for reviewing! Please let me know if further changes are required.